### PR TITLE
🐛 修复使用 go-cqhttp 生成的配置文件时进程无法启动的问题 

### DIFF
--- a/nonebot_plugin_gocqhttp/process/device/models.py
+++ b/nonebot_plugin_gocqhttp/process/device/models.py
@@ -26,7 +26,7 @@ class ShortDeviceInfo(BaseModel):
     mac_address: str
     ip_address: List[int] = Field(max_items=4, min_items=4)
     imei: str
-    incremental: str
+    incremental: str = ""
 
     protocol: AccountProtocol
 


### PR DESCRIPTION
```
    return DeviceInfo.parse_obj(content)
  File "pydantic/main.py", line 527, in pydantic.main.BaseModel.parse_obj
    return cls(**obj)
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
    raise validation_error
pydantic.error_wrappers.ValidationError: 1 validation error for DeviceInfo
incremental
  field required (type=value_error.missing)
```