### PR TITLE
🐛 Fix `sim_info` field error in device info

### DIFF
--- a/nonebot_plugin_gocqhttp/process/device/models.py
+++ b/nonebot_plugin_gocqhttp/process/device/models.py
@@ -37,6 +37,7 @@ class DeviceInfo(ShortDeviceInfo):
     proc_version: str
     baseband: str = ""
     sim: str = "T-Mobile"
+    sim_info: str = "T-Mobile"
     os_type: str = "android"
     bootloader: str = "U-boot"
     wifi_bssid: str


### PR DESCRIPTION
go-cq 那边很久以前就是 sim_info 了。不确定是 nonebot-plugin-gocqhttp 写错了，还是 go-cq 后来版本更新了

![)~L%M887V 28ZUOQ6JOJY(0](https://user-images.githubusercontent.com/18511905/226089418-dc3f219d-29a0-425f-919a-8ac833d003f7.png)

本着可能存在的兼容性问题，还是加上正确的好了，原来的就不动了